### PR TITLE
FIX: Center and fit auth button to text content.

### DIFF
--- a/src/services/social-auth/facebook/facebook-auth.tsx
+++ b/src/services/social-auth/facebook/facebook-auth.tsx
@@ -44,7 +44,11 @@ export default function FacebookAuth() {
 
   return (
     <>
-      <Button variant="contained" color="primary" onClick={onLogin}>
+      <Button variant="contained"
+        sx={{
+          display: 'flex',
+          margin: 'auto',
+        }} color="primary" onClick={onLogin}>
         {t("common:auth.facebook.action")}
       </Button>
       <FullPageLoader isLoading={isLoading} />

--- a/src/services/social-auth/google/google-auth.tsx
+++ b/src/services/social-auth/google/google-auth.tsx
@@ -8,6 +8,7 @@ import { CredentialResponse, GoogleLogin } from "@react-oauth/google";
 import { useState } from "react";
 import { FullPageLoader } from "@/components/full-page-loader";
 import useLanguage from "@/services/i18n/use-language";
+import Button from "@mui/material/Button";
 
 export default function GoogleAuth() {
   const { setUser } = useAuthActions();
@@ -38,7 +39,22 @@ export default function GoogleAuth() {
 
   return (
     <>
+    <Button
+      variant="contained"
+      sx={{
+        display: 'flex',
+        margin: 'auto',
+        padding: 0,
+        backgroundColor: 'transparent',
+        border: 'none',
+        boxShadow: 'none',
+        '&:hover': {
+          backgroundColor: 'transparent',
+        },
+      }}
+    >
       <GoogleLogin onSuccess={onSuccess} locale={language} />
+    </Button>
       <FullPageLoader isLoading={isLoading} />
     </>
   );


### PR DESCRIPTION
Updated the styling of the buttons for consistency. Before, my Safari browser would load the Google auth button, but immediately resize the button and offset from the centre. That's not ideal, so I applied my own fix, screenshotted below.

![image](https://github.com/user-attachments/assets/125efed9-ba78-435f-a1f0-4d50194adaad)
